### PR TITLE
Equipos guarda personajes en vez de jugadores

### DIFF
--- a/prisma/migrations/20250212172428_replace_team_players_with_characters/migration.sql
+++ b/prisma/migrations/20250212172428_replace_team_players_with_characters/migration.sql
@@ -1,0 +1,86 @@
+/*
+  Warnings:
+
+  - You are about to drop the column `player1Username` on the `Team` table. All the data in the column will be lost.
+  - You are about to drop the column `player2Username` on the `Team` table. All the data in the column will be lost.
+  - You are about to drop the column `player3Username` on the `Team` table. All the data in the column will be lost.
+  - You are about to drop the column `player4Username` on the `Team` table. All the data in the column will be lost.
+  - You are about to drop the column `player5Username` on the `Team` table. All the data in the column will be lost.
+  - Added the required column `character1Id` to the `Team` table without a default value. This is not possible if the table is not empty.
+  - Added the required column `character2Id` to the `Team` table without a default value. This is not possible if the table is not empty.
+  - Added the required column `character3Id` to the `Team` table without a default value. This is not possible if the table is not empty.
+  - Added the required column `character4Id` to the `Team` table without a default value. This is not possible if the table is not empty.
+  - Added the required column `character5Id` to the `Team` table without a default value. This is not possible if the table is not empty.
+
+*/
+-- DropForeignKey
+ALTER TABLE "Team" DROP CONSTRAINT "Team_player1Username_fkey";
+
+-- DropForeignKey
+ALTER TABLE "Team" DROP CONSTRAINT "Team_player2Username_fkey";
+
+-- DropForeignKey
+ALTER TABLE "Team" DROP CONSTRAINT "Team_player3Username_fkey";
+
+-- DropForeignKey
+ALTER TABLE "Team" DROP CONSTRAINT "Team_player4Username_fkey";
+
+-- DropForeignKey
+ALTER TABLE "Team" DROP CONSTRAINT "Team_player5Username_fkey";
+
+-- DropIndex
+DROP INDEX "Team_player1Username_idx";
+
+-- DropIndex
+DROP INDEX "Team_player2Username_idx";
+
+-- DropIndex
+DROP INDEX "Team_player3Username_idx";
+
+-- DropIndex
+DROP INDEX "Team_player4Username_idx";
+
+-- DropIndex
+DROP INDEX "Team_player5Username_idx";
+
+-- AlterTable
+ALTER TABLE "Team" DROP COLUMN "player1Username",
+DROP COLUMN "player2Username",
+DROP COLUMN "player3Username",
+DROP COLUMN "player4Username",
+DROP COLUMN "player5Username",
+ADD COLUMN     "character1Id" INTEGER NOT NULL,
+ADD COLUMN     "character2Id" INTEGER NOT NULL,
+ADD COLUMN     "character3Id" INTEGER NOT NULL,
+ADD COLUMN     "character4Id" INTEGER NOT NULL,
+ADD COLUMN     "character5Id" INTEGER NOT NULL;
+
+-- CreateIndex
+CREATE INDEX "Team_character1Id_idx" ON "Team"("character1Id");
+
+-- CreateIndex
+CREATE INDEX "Team_character2Id_idx" ON "Team"("character2Id");
+
+-- CreateIndex
+CREATE INDEX "Team_character3Id_idx" ON "Team"("character3Id");
+
+-- CreateIndex
+CREATE INDEX "Team_character4Id_idx" ON "Team"("character4Id");
+
+-- CreateIndex
+CREATE INDEX "Team_character5Id_idx" ON "Team"("character5Id");
+
+-- AddForeignKey
+ALTER TABLE "Team" ADD CONSTRAINT "Team_character1Id_fkey" FOREIGN KEY ("character1Id") REFERENCES "Character"("id") ON DELETE RESTRICT ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "Team" ADD CONSTRAINT "Team_character2Id_fkey" FOREIGN KEY ("character2Id") REFERENCES "Character"("id") ON DELETE RESTRICT ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "Team" ADD CONSTRAINT "Team_character3Id_fkey" FOREIGN KEY ("character3Id") REFERENCES "Character"("id") ON DELETE RESTRICT ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "Team" ADD CONSTRAINT "Team_character4Id_fkey" FOREIGN KEY ("character4Id") REFERENCES "Character"("id") ON DELETE RESTRICT ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "Team" ADD CONSTRAINT "Team_character5Id_fkey" FOREIGN KEY ("character5Id") REFERENCES "Character"("id") ON DELETE RESTRICT ON UPDATE CASCADE;

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -6,6 +6,7 @@
 
 generator client {
   provider = "prisma-client-js"
+  binaryTargets = ["native", "linux-arm64-openssl-3.0.x"]
 }
 
 datasource db {
@@ -20,37 +21,32 @@ model Player {
   level        Int
   victories    Int
   defeats      Int
-  teamPlayer1  Team[] @relation("TeamPlayer1")
-  teamPlayer2  Team[] @relation("TeamPlayer2")
-  teamPlayer3  Team[] @relation("TeamPlayer3")
-  teamPlayer4  Team[] @relation("TeamPlayer4")
-  teamPlayer5  Team[] @relation("TeamPlayer5")
   characters   Character[]
   createdAt   DateTime @default(now())
   updatedAt   DateTime @updatedAt
 }
 
 model Team {
-  id      Int    @id @default(autoincrement())
-  name    String
-  player1 Player @relation("TeamPlayer1", fields: [player1Username], references: [username])
-  player2 Player @relation("TeamPlayer2", fields: [player2Username], references: [username])
-  player3 Player @relation("TeamPlayer3", fields: [player3Username], references: [username])
-  player4 Player @relation("TeamPlayer4", fields: [player4Username], references: [username])
-  player5 Player @relation("TeamPlayer5", fields: [player5Username], references: [username])
-  player1Username String
-  player2Username String
-  player3Username String
-  player4Username String
-  player5Username String
-  createdAt   DateTime @default(now())
-  updatedAt   DateTime @updatedAt
+  id            Int        @id @default(autoincrement())
+  name          String
+  character1    Character  @relation("TeamCharacter1", fields: [character1Id], references: [id])
+  character2    Character  @relation("TeamCharacter2", fields: [character2Id], references: [id])
+  character3    Character  @relation("TeamCharacter3", fields: [character3Id], references: [id])
+  character4    Character  @relation("TeamCharacter4", fields: [character4Id], references: [id])
+  character5    Character  @relation("TeamCharacter5", fields: [character5Id], references: [id])
+  character1Id  Int
+  character2Id  Int
+  character3Id  Int
+  character4Id  Int
+  character5Id  Int
+  createdAt     DateTime   @default(now())
+  updatedAt     DateTime   @updatedAt
 
-  @@index([player1Username])
-  @@index([player2Username])
-  @@index([player3Username])
-  @@index([player4Username])
-  @@index([player5Username])
+  @@index([character1Id])
+  @@index([character2Id])
+  @@index([character3Id])
+  @@index([character4Id])
+  @@index([character5Id])
 }
 
 model Character {
@@ -64,6 +60,11 @@ model Character {
   playerUsername String
   createdAt   DateTime @default(now())
   updatedAt   DateTime @updatedAt
+  teamCharacter1 Team[] @relation("TeamCharacter1")
+  teamCharacter2 Team[] @relation("TeamCharacter2")
+  teamCharacter3 Team[] @relation("TeamCharacter3")
+  teamCharacter4 Team[] @relation("TeamCharacter4")
+  teamCharacter5 Team[] @relation("TeamCharacter5")
 
   @@index([playerUsername])
 }


### PR DESCRIPTION
Corrijo el modelo de equipo. Debia guardar personajes en vez de jugadores

### ⚠️ **Consideraciones:**

- Si ya se ejecuto la aplicacion con una base de datos persistida (postgress instalado en local o docker con volumen) se debe ejecutar `npx prisma migrate dev` para actualizar los modelos de la base de datos.