### PR TITLE
Arregla la ejecución de Prisma Migrate en el Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -14,8 +14,5 @@ COPY . .
 # Genera el cliente de Prisma
 RUN npx prisma generate
 
-# Ejecuta las migraciones de Prisma
-RUN npx prisma migrate deploy
-
-# Comando para iniciar la aplicación
-CMD ["node", "app.js"]
+# Ejecuta Prisma migrate deploy al inicio del contenedor
+CMD npx prisma migrate deploy && node app.js


### PR DESCRIPTION
En este PR se ajusta el Dockerfile para que las migraciones de Prisma (npx prisma migrate deploy) se ejecuten al iniciar el contenedor en lugar de durante la construcción de la imagen.
    
Antes, las migraciones se ejecutaban en la fase de construcción (RUN), lo que no garantizaba que se aplicaran siempre en el entorno de producción. Ahora, al moverlas a CMD, se aseguran de ejecutarse cada vez que el contenedor inicia.

Cambios realizados:

- Se eliminó RUN npx prisma migrate deploy
- Ahora se ejecuta en CMD junto con node app.js